### PR TITLE
Use Github Container Registry instead of Github Packages

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: rtasson/vault-ocsp/vault-ocsp
+          registry: ghcr.io
+          repository: rtasson/vault-ocsp
           tag_with_ref: true
 


### PR DESCRIPTION
With guidance from [the docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry).